### PR TITLE
Enter key should add newline for non-Ruby files

### DIFF
--- a/yardoc.py
+++ b/yardoc.py
@@ -36,9 +36,11 @@ class YardocCommand(sublime_plugin.TextCommand):
         point = self.view.sel()[0].end()
         scope = self.view.scope_name(point)
         if not re.search("source\\.ruby", scope):
+            self.view.insert(edit, point, "\n")
             return
         line = self.read_line(point + 1)
         if not self.check_doc(point):
+            self.view.insert(edit, point, "\n")
             return
         doc = self.compose_doc(line, edit)
         self.write(self.view, doc)
@@ -133,6 +135,7 @@ class AddhashtagCommand(YardocCommand):
         point = self.view.sel()[0].end()
         scope = self.view.scope_name(point)
         if not re.search("source\\.ruby", scope):
+            self.view.insert(edit, point, "\n")
             return
         line = "\n" + "# "
         self.write(self.view, line)


### PR DESCRIPTION
This allows the enter key to insert a newline in a line beginning
with "#" if the document is not a Ruby source file. Returning from
the command does not fall-through to the execution of the
key-binding.

Note that inserting "\n" might cause issues with files formatted
with different EOL settings (\r\n on Windows). I have not tested
this, but I don't know any better way to handle this use case.
It seems that the plugin already uses \n elsewhere, though.
