### PR TITLE
A white space after the "@param" string is removed.

### DIFF
--- a/yardoc.py
+++ b/yardoc.py
@@ -115,7 +115,7 @@ class YardocCommand(sublime_plugin.TextCommand):
         lines.append("# ${1:[%s description]}" % (method_name))
 
         for param in params:
-            lines.append("# @param  %s [${1:type}] ${1:[description]}" % (param))
+	     lines.append("# @param %s [${1:type}] ${1:[description]}" % (param))
 
         lines.append("#" + self.trailing_spaces)
         lines.append("# @return [${1:type}] ${1:[description]}")


### PR DESCRIPTION
A white space after the "@param" string is removed to maintain consistency with other tags and also to comply with the official @tag-style syntax.
Ref: http://rubydoc.info/gems/yard/file/docs/GettingStarted.md
