### PR TITLE
Creating a keymap file for sublime on Linux

### DIFF
--- a/Default (Linux).sublime-keymap
+++ b/Default (Linux).sublime-keymap
@@ -1,0 +1,1 @@
+{ "keys": ["ctrl+enter"], "command": "yardoc"}


### PR DESCRIPTION
When using the plugin on ST3 for Linux the key commands were working properly. This should alleviate that problem.